### PR TITLE
Borrow matchit support from html.vim into heex.vim

### DIFF
--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -13,4 +13,16 @@ setlocal shiftwidth=2 softtabstop=2 expandtab
 setlocal comments=:<%!--
 setlocal commentstring=<%!--\ %s\ --%>
 
+" HTML: thanks to Johannes Zellner and Benji Fisher.
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_ignorecase = 1
+  let b:match_words = '<!--:-->,' ..
+	\	      '<:>,' ..
+	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
+	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
+	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+  let b:html_set_match_words = 1
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
+endif
+
 let b:undo_ftplugin = 'set sw< sts< et< com< cms<'


### PR DESCRIPTION
Makes use of `%` in `heex` files to behave the same as `html` files, for example to easily move the cursor between an opening `<div>` and its closing `</div>`.